### PR TITLE
Refactor systemd unit file creation to use python-systemdunit

### DIFF
--- a/src/rolekit/server/io/systemd.py
+++ b/src/rolekit/server/io/systemd.py
@@ -104,7 +104,7 @@ class SystemdContainerServiceUnit():
             self.env = {}
 
     def write(self):
-        path = "%s/%s.service" % (systemd_units, self.container_name)
+        path = "%s/%s.service" % (SYSTEMD_UNITS, self.container_name)
 
         docker_run = "/usr/bin/docker run --name=%s" % self.container_name
         for key in self.env:

--- a/src/rolekit/server/io/systemd.py
+++ b/src/rolekit/server/io/systemd.py
@@ -137,19 +137,6 @@ class SystemdContainerServiceUnit():
         with open(path, "w") as f:
             self.unitfile.write(f)
 
-        """with open(path, "w") as f:
-            f.write("[Unit]\n")
-            f.write("Description=%s\n" % self.desc)
-            f.write("Requires=docker.service\n")
-            f.write("After=docker.service\n\n")
-            f.write("[Service]\n")
-            f.write("Restart=always\n")
-            f.write("ExecStart=%s\n" % docker_run)
-            f.write("ExecStop=/usr/bin/docker stop -t 5 {0} ; /usr/bin/docker rm -f {0}\n\n".format(self.container_name))
-            f.write("[Install]\n")
-            f.write("WantedBy=multi-user.target\n")"""
-
-
 """
 Sections of this parser are adapted from:
 

--- a/src/rolekit/server/io/systemd.py
+++ b/src/rolekit/server/io/systemd.py
@@ -105,8 +105,6 @@ class SystemdContainerServiceUnit():
 
     def write(self):
         path = "%s/%s.service" % (systemd_units, self.container_name)
-        # uncomment for local testing
-        #path = "%s/%s.service" % ('/tmp', self.container_name)
 
         docker_run = "/usr/bin/docker run --name=%s" % self.container_name
         for key in self.env:

--- a/tests/systemd_unit_tests.py
+++ b/tests/systemd_unit_tests.py
@@ -1,0 +1,10 @@
+from rolekit.server.io.systemd import SystemdContainerServiceUnit
+
+img = 'testimage'
+cont = 'testcontainer'
+desc = 'this test container'
+env = {'var_y': 'value_y', 'var_x': 'value_x'}
+ports = [8080, 443]
+
+s = SystemdContainerServiceUnit(image_name=img, container_name=cont, desc=desc, env=env, ports=ports)
+s.write()


### PR DESCRIPTION
Please refer to #17 for more details on this.  Refactored `SystemdContainerServiceUnit`  to use `SystemdUnitParser` in `rolekit.server.io.systemd`.  Then I did a bit of cleanup.
